### PR TITLE
[Bugfix] Skip genesis block sync when fromBlock == toBlock == 

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -2,18 +2,19 @@ package common
 
 // for common
 const (
-	EmptyString       = ""
-	ZeroByte          = byte(0x00)
-	DateOutputFormat  = "2006-01-02T15:04:05.999999"
-	BigIntSize        = 32 // bytes
-	CheckSumLen       = 4  // bytes
-	AESKeySize        = 32 // bytes
-	Int32Size         = 4  // bytes
-	Uint32Size        = 4  // bytes
-	Uint64Size        = 8  // bytes
-	HashSize          = 32 // bytes
-	MaxHashStringSize = HashSize * 2
-	Base58Version     = 0
+	EmptyString        = ""
+	ZeroByte           = byte(0x00)
+	DateOutputFormat   = "2006-01-02T15:04:05.999999"
+	BigIntSize         = 32 // bytes
+	CheckSumLen        = 4  // bytes
+	AESKeySize         = 32 // bytes
+	Int32Size          = 4  // bytes
+	Uint32Size         = 4  // bytes
+	Uint64Size         = 8  // bytes
+	HashSize           = 32 // bytes
+	MaxHashStringSize  = HashSize * 2
+	Base58Version      = 0
+	GenesisBlockHeight = 1
 )
 
 // size data for incognito key and signature


### PR DESCRIPTION
## Overview
This MR fixes an issue where the Incognito server fails to start because it tries to fetch the genesis block from Highway, which doesn't store genesis block information.
## Issues
- Server Incogito Startup Failure
- Evidence: 
<img width="1037" alt="Screenshot 2025-04-26 at 18 01 45" src="https://github.com/user-attachments/assets/e3c7b9ac-259b-4292-9a56-8a5cb2061e63" />

## Root Cause
- The genesis block is typically hardcoded or stored locally, but the current logic mistakenly tries to fetch it from Highway.
- Highway does not store the genesis block (only subsequent blocks), so it throws an RPC error:
<img width="1022" alt="Screenshot 2025-04-26 at 18 04 08" src="https://github.com/user-attachments/assets/15f411b7-679b-4d51-88d1-53ef3255d55c" />

## Solution
- Modified the block sync logic to skip the stream request when fromBlock == toBlock == 1.